### PR TITLE
Add `when` as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "gulp-uglify": "^1.0.1",
     "jshint-stylish": "^0.4.0",
     "uglifyify": "^2.5.0",
-    "vinyl-source-stream": "^1.0.0"
+    "vinyl-source-stream": "^1.0.0",
+    "when": "^3.7.2"
   },
   "engines": {
     "node": ">=0.10.x",


### PR DESCRIPTION
Had this exception when running the dev server:

    events.js:72
            throw er; // Unhandled 'error' event
                  ^
    Error: Cannot find module 'when' from '/Users/chuck/Projects/galaxy.js-mobile-gamepad/node_modules/plink/lib'
        at /Users/chuck/Projects/galaxy.js-mobile-gamepad/node_modules/browserify/node_modules/browser-resolve/node_modules/resolve/lib/async.js:50:17
        at process (/Users/chuck/Projects/galaxy.js-mobile-gamepad/node_modules/browserify/node_modules/browser-resolve/node_modules/resolve/lib/async.js:119:43)
        at /Users/chuck/Projects/galaxy.js-mobile-gamepad/node_modules/browserify/node_modules/browser-resolve/node_modules/resolve/lib/async.js:128:21
        at load (/Users/chuck/Projects/galaxy.js-mobile-gamepad/node_modules/browserify/node_modules/browser-resolve/node_modules/resolve/lib/async.js:60:43)
        at /Users/chuck/Projects/galaxy.js-mobile-gamepad/node_modules/browserify/node_modules/browser-resolve/node_modules/resolve/lib/async.js:66:22
        at /Users/chuck/Projects/galaxy.js-mobile-gamepad/node_modules/browserify/node_modules/browser-resolve/node_modules/resolve/lib/async.js:21:47
        at Object.oncomplete (fs.js:108:15)

It's not our fault, and we probably don't want to upstream this, but installing `when` myself fixed it. Figured I'd PR it for posterity.